### PR TITLE
なぞってN+1解消: order by ないことで最終的なクエリ結果が不定になっていてバリデーションこけてるのではないか

### DIFF
--- a/isuumo/webapp/go/main.go
+++ b/isuumo/webapp/go/main.go
@@ -869,7 +869,7 @@ func searchEstateNazotte(c echo.Context) error {
 	b := coordinates.getBoundingBox()
 
 	estateIdsInBoundingBox := []EstateID{}
-	query := `SELECT id FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY popularity DESC, id ASC`
+	query := `SELECT id FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ?`
 	err = db.Select(&estateIdsInBoundingBox, query, b.BottomRightCorner.Latitude, b.TopLeftCorner.Latitude, b.BottomRightCorner.Longitude, b.TopLeftCorner.Longitude)
 	if err == sql.ErrNoRows {
 		c.Echo().Logger.Infof("select * from estate where latitude ...", err)
@@ -898,6 +898,7 @@ func searchEstateNazotte(c echo.Context) error {
 					ST_PolygonFromText(%s), 
 					ST_GeomFromText(CONCAT("POINT(", latitude, " ", longitude, ")"))
 				)
+			ORDER BY popularity DESC, id ASC
 		`,
 		estateIdsInBoundingBoxJoined,
 		coordinates.coordinatesToText(),


### PR DESCRIPTION
fix https://portal.isucon.net/contestant/benchmark_jobs/5022

Reason: アプリケーション互換性チェックに失敗しました

```
{"pass":false,"score":0,"messages":[{"text":"POST /api/estate/nazotte: レスポンスが不正です","count":4}],"language":"go"}
```